### PR TITLE
recognize regenerator generators too

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-var co = require('co');
+var co = require('co'),
+    isGeneratorFn = require('is-generator').fn;
 
 var DEFAULT_METHODS = [
     'afterAll',
@@ -40,7 +41,7 @@ function coifyJasmineFn(fname) {
     global[fname] = function() {
         var expectsName = arguments.length > 1; // `it('does stuff', fn)` (length 2) vs `beforeEach(fn)` (length 1)
         var userFn = expectsName ? arguments[1] : arguments[0];
-        if (/^function\s*\*/.test(userFn.toString())) {
+        if (isGeneratorFn(userFn)) {
             // if the user method is a generator:
             //   1. call it with the correct `this` context object
             //   2. wrap it in a co function which fails the spec if an exception is

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "Ben Loveridge <bloveridge@gmail.com>"
   ],
   "dependencies": {
-    "co": "^4.6.0"
+    "co": "^4.6.0",
+    "is-generator": "^1.0.2"
   },
   "devDependencies": {
     "jasmine": "^2.3.2"


### PR DESCRIPTION
Hi! This p.r. replaces the `/^function\s*\*/` test with [is-generator](https://github.com/blakeembrey/is-generator), which is capable of detecting native generators as well as those transformed by Babel’s regenerator runtime. Hopefully this will allow some reuse in [projects like this](https://github.com/webdriverio/webdriverio/blob/1a99d8fa6374cfd53ecca408e0b991858899b881/lib/frameworks/jasmine.js#L204-L249), where that whole chunk might be replaced with jasmine-co. Feedback welcome.
